### PR TITLE
tiledb optimize

### DIFF
--- a/kerasAC/tiledb_generators.py
+++ b/kerasAC/tiledb_generators.py
@@ -38,9 +38,21 @@ def get_upsampled_indices(data_arrays,
         print(t2-t1)
         non_upsampled_indices_chrom=np.setdiff1d(np.array(range(chrom_size)),
                                            upsampled_indices_chrom)
-        t3 = time.time()
+        t3_1 = time.time()
+        print(t3_1 - t2)
+        non_upsampled_indices_chrom_=np.delete(np.array(range(chrom_size)),
+                                           upsampled_indices_chrom)
+        t3_2 = time.time()
+        print(t3_2 - t3_1)
+        mask = np.zeros(chrom_size,dtype=bool)
+        mask[upsampled_indices_chrom] = True
+        non_upsampled_indices_chrom__ = np.array(range(chrom_size))[~mask]
+        t3_3 = time.time()
         print("got indices to NOT upsampled for chrom:"+str(chrom))
-        print(t3-t2)
+        print(t3_3-t3_2)
+        print(non_upsampled_indices_chrom.shape, non_upsampled_indices_chrom_.shape, non_upsampled_indices_chrom__.shape)
+        print(np.array_equal(non_upsampled_indices_chrom, non_upsampled_indices_chrom_))
+        print(np.array_equal(non_upsampled_indices_chrom, non_upsampled_indices_chrom__))
         upsampled_chrom_name_array=[chrom]*upsampled_indices_chrom.shape[0]
         non_upsampled_chrom_name_array=[chrom]*non_upsampled_indices_chrom.shape[0]
 	
@@ -52,7 +64,7 @@ def get_upsampled_indices(data_arrays,
                                                    'indices':non_upsampled_indices_chrom.flatten()})
         print("generated coord dataframes for chrom:"+str(chrom))
         t4 = time.time()
-        print(t4-t3)
+        print(t4-t3_2)
         if upsampled_indices is None:
             upsampled_indices=cur_upsampled_df
             non_upsampled_indices=cur_non_upsampled_df

--- a/kerasAC/tiledb_generators.py
+++ b/kerasAC/tiledb_generators.py
@@ -39,6 +39,7 @@ def get_upsampled_indices(data_arrays,
         upsampled_chrom_name_array=[chrom]*upsampled_indices_chrom.shape[0]
         non_upsampled_chrom_name_array=[chrom]*non_upsampled_indices_chrom.shape[0]
 
+        print("upsampled_chrom_name_array ", upsampled_chrom_name_array.shape, "non_upsampled_chrom_name_array ", non_upsampled_chrom_name_array.shape)
         cur_upsampled_df=pd.DataFrame.from_dict({'chrom':upsampled_chrom_name_array,
                                                'indices':upsampled_indices_chrom})
         cur_non_upsampled_df=pd.DataFrame.from_dict({'chrom':non_upsampled_chrom_name_array,

--- a/kerasAC/tiledb_generators.py
+++ b/kerasAC/tiledb_generators.py
@@ -7,7 +7,6 @@ import pysam
 from .util import *
 import tiledb
 import pdb 
-import time
 
 def get_upsampled_indices(data_arrays,
                           partition_attribute_for_upsample,
@@ -21,7 +20,6 @@ def get_upsampled_indices(data_arrays,
         upsampled_indices_chrom=None
         non_upsampled_indices_chrom=None
         chrom_size=None
-        t1 = time.time()
         for task in data_arrays[chrom]:
             cur_vals=data_arrays[chrom][task][:][partition_attribute_for_upsample]
             if chrom_size is None:
@@ -33,38 +31,21 @@ def get_upsampled_indices(data_arrays,
                 upsampled_indices_chrom=upsampled_indices_task_chrom
             else:
                 upsampled_indices_chrom=np.union1d(upsampled_indices_chrom,upsampled_indices_task_chrom)
-        t2 = time.time()
         print("got indices to upsample for chrom:"+str(chrom))
-        print(t2-t1)
-        non_upsampled_indices_chrom=np.setdiff1d(np.array(range(chrom_size)),
-                                           upsampled_indices_chrom)
-        t3_1 = time.time()
-        print(t3_1 - t2)
-        non_upsampled_indices_chrom_=np.delete(np.array(range(chrom_size)),
-                                           upsampled_indices_chrom)
-        t3_2 = time.time()
-        print(t3_2 - t3_1)
-        mask = np.zeros(chrom_size,dtype=bool)
+
+        mask = np.zeros(chrom_size, dtype=bool)
         mask[upsampled_indices_chrom] = True
-        non_upsampled_indices_chrom__ = np.array(range(chrom_size))[~mask]
-        t3_3 = time.time()
+        non_upsampled_indices_chrom = np.array(range(chrom_size))[~mask]
         print("got indices to NOT upsampled for chrom:"+str(chrom))
-        print(t3_3-t3_2)
-        print(non_upsampled_indices_chrom.shape, non_upsampled_indices_chrom_.shape, non_upsampled_indices_chrom__.shape)
-        print(np.array_equal(non_upsampled_indices_chrom, non_upsampled_indices_chrom_))
-        print(np.array_equal(non_upsampled_indices_chrom, non_upsampled_indices_chrom__))
+
         upsampled_chrom_name_array=[chrom]*upsampled_indices_chrom.shape[0]
         non_upsampled_chrom_name_array=[chrom]*non_upsampled_indices_chrom.shape[0]
-	
-        print(len(upsampled_chrom_name_array), upsampled_chrom_name_array[0:20])
-        print(upsampled_indices_chrom.shape, upsampled_indices_chrom[0:20])
+
         cur_upsampled_df=pd.DataFrame.from_dict({'chrom':upsampled_chrom_name_array,
                                                'indices':upsampled_indices_chrom.flatten()})
         cur_non_upsampled_df=pd.DataFrame.from_dict({'chrom':non_upsampled_chrom_name_array,
                                                    'indices':non_upsampled_indices_chrom.flatten()})
         print("generated coord dataframes for chrom:"+str(chrom))
-        t4 = time.time()
-        print(t4-t3_2)
         if upsampled_indices is None:
             upsampled_indices=cur_upsampled_df
             non_upsampled_indices=cur_non_upsampled_df
@@ -72,15 +53,11 @@ def get_upsampled_indices(data_arrays,
             upsampled_indices=pd.concat([upsampled_indices,cur_upsampled_df],axis=0)
             non_upsampled_indices=pd.concat([non_upsampled_indices,cur_non_upsampled_df],axis=0)
         print("added chrom coords to master list")
-        t5 = time.time()
-        print(t5-t4)
-        
+
     if shuffle==True:
         print("shuffling upsampled and non-upsampled dataframes prior to start of training")
         upsampled_indices.apply(np.random.shuffle,axis=0)
         non_upsampled_indices.apply(np.random.shuffle,axis=0)
-        t6 = time.time()
-        print(t6-t5)
 
     print("finished generator init")
     return upsampled_indices,non_upsampled_indices 


### PR DESCRIPTION
Used a negative mask to create the non_upsampled_indices_chrom array.  Using `delete` instead of `setdiff1d` saves 20-25% time, the masking approach takes almost the same time as `delete` but marginally faster in some cases. The masking feels more elegant, so retaining that.

Verified that the resulting arrays are the same in all cases by checking the length and using `np.array_equal`